### PR TITLE
Improved Naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+yarn-error.log
 
 # Ignore user config files
 .vscode/

--- a/packages/cdk-appconfig-examples/lib/hosted-configuration-stack.ts
+++ b/packages/cdk-appconfig-examples/lib/hosted-configuration-stack.ts
@@ -48,7 +48,7 @@ export class HostedConfigurationStack extends cdk.Stack {
       name: 'prod'
     });
 
-    this.strategy = appconfig.DeploymentStrategy.fromPredefined(
+    this.strategy = appconfig.DeploymentStrategy.fromDeploymentStrategyId(
       this,
       'Strategy',
       appconfig.PredefinedDeploymentStrategy.ALL_AT_ONCE

--- a/packages/cdk-appconfig-examples/lib/hosted-configuration-stack.ts
+++ b/packages/cdk-appconfig-examples/lib/hosted-configuration-stack.ts
@@ -4,15 +4,22 @@ import * as cdk from '@aws-cdk/core';
 import * as appconfig from '@cuperman/cdk-appconfig';
 
 export class HostedConfigurationStack extends cdk.Stack {
+  public app: appconfig.IApplication;
+  public profile: appconfig.IConfigurationProfile;
+  public version: appconfig.IHostedConfigurationVersion;
+  public env: appconfig.IEnvironment;
+  public strategy: appconfig.IDeploymentStrategy;
+  public deployment: appconfig.Deployment;
+
   constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    const app = new appconfig.Application(this, 'App', {
+    this.app = new appconfig.Application(this, 'App', {
       name: 'Hosted Configuration Example'
     });
 
-    const profile = new appconfig.HostedConfigurationProfile(this, 'Profile', {
-      application: app,
+    this.profile = new appconfig.HostedConfigurationProfile(this, 'Profile', {
+      application: this.app,
       name: 'Hosted Configuration Profile',
       validators: [
         appconfig.JsonSchemaValidator.fromInline(
@@ -29,30 +36,30 @@ export class HostedConfigurationStack extends cdk.Stack {
       ]
     });
 
-    const version = new appconfig.HostedConfigurationVersion(this, 'Version', {
-      application: app,
-      configurationProfile: profile,
+    this.version = new appconfig.HostedConfigurationVersion(this, 'Version', {
+      application: this.app,
+      configurationProfile: this.profile,
       contentType: appconfig.ContentType.JSON,
       content: appconfig.Content.fromAsset(path.join(__dirname, '../config/hosted_config.json'))
     });
 
-    const env = new appconfig.Environment(this, 'Env', {
-      application: app,
+    this.env = new appconfig.Environment(this, 'Env', {
+      application: this.app,
       name: 'prod'
     });
 
-    const strategy = appconfig.DeploymentStrategy.fromPredefined(
+    this.strategy = appconfig.DeploymentStrategy.fromPredefined(
       this,
       'Strategy',
       appconfig.PredefinedDeploymentStrategy.ALL_AT_ONCE
     );
 
-    new appconfig.Deployment(this, 'Deployment', {
-      application: app,
-      configurationProfile: profile,
-      configurationVersionNumber: version.versionNumber,
-      environment: env,
-      deploymentStrategy: strategy
+    this.deployment = new appconfig.Deployment(this, 'Deployment', {
+      application: this.app,
+      configurationProfile: this.profile,
+      configurationVersionNumber: this.version.versionNumber,
+      environment: this.env,
+      deploymentStrategy: this.strategy
     });
   }
 }

--- a/packages/cdk-appconfig/README.md
+++ b/packages/cdk-appconfig/README.md
@@ -32,13 +32,10 @@ import * as appconfig from '@cuperman/cdk-appconfig';
 
 const configBucket = new s3.Bucket(this, 'ConfigBucket');
 
-const app = new appconfig.Application(this, 'App', {
-  name: 'My Application'
-});
+const app = new appconfig.Application(this, 'App');
 
 const configProfile = new appconfig.S3ConfigurationProfile(this, 'ConfigProfile', {
   application: app,
-  name: 'My Configuration Profile',
   s3Bucket: configBucket,
   s3ObjectKey: 'path/to/config.json'
 });
@@ -65,13 +62,10 @@ Example of using CDK assets to manage AppConfig hosted configurations:
 ```ts
 import * as appconfig from '@cuperman/cdk-appconfig';
 
-const app = new appconfig.Application(this, 'App', {
-  name: 'My Application'
-});
+const app = new appconfig.Application(this, 'App');
 
 const configProfile = new appconfig.HostedConfigurationProfile(this, 'ConfigProfile', {
-  application: app,
-  name: 'My Configuration Profile'
+  application: app
 });
 
 new appconfig.HostedConfigurationVersion(this, 'ConfigVersion', {
@@ -97,7 +91,6 @@ Example defining inline JSON schema:
 ```ts
 new appconfig.HostedConfigurationProfile(this, 'Config', {
   application: app,
-  name: 'My Config',
   validators: [
     appconfig.JsonSchemaValidator.fromInline(`{
       "$schema": "http://json-schema.org/draft-04/schema#",
@@ -127,7 +120,6 @@ const validator = new lambda.Function(this, 'Validator', { ... });
 
 new appconfig.HostedConfigurationProfile(this, 'Config', {
   application: app,
-  name: 'My Config',
   validators: [
     appconfig.LambdaValidator.fromLambdaFunction(validator)
   ]
@@ -148,12 +140,9 @@ const app = new appconfig.Application( ... );
 const configProfile = new appconfig.HostedConfigurationProfile( ... );
 const configVersion = new appconfig.HostedConfigurationVersion( ... );
 
-const env = new appconfig.Environment(this, 'Env', {
-  name: 'Production'
-});
+const prodEnv = new appconfig.Environment(this, 'ProdEnv');
 
-const strategy = new appconfig.DeploymentStrategy(this, 'Stratey', {
-  name: 'Exponential Rollout',
+const exponentialStrategy = new appconfig.DeploymentStrategy(this, 'ExponentialStrategy', {
   growthType: appconfig.DeploymentStrategyGrowthType.EXPONENTIAL,
   growthFactor: 2,
   deploymentDurationInMinutes: 10,
@@ -164,8 +153,8 @@ new appconfig.Deployment(this, 'Deployment', {
   application: app,
   configurationProfile: configProfile,
   configurationVersionNumber: configVersion.versionNumber,
-  environment: env,
-  deploymentStrategy: strategy
+  environment: prodEnv,
+  deploymentStrategy: exponentialStrategy
 });
 ```
 
@@ -180,7 +169,7 @@ new appconfig.Deployment(this, 'Deployment', {
   application: app,
   configurationProfile: configProfile,
   configurationVersionNumber: configVersion.versionNumber,
-  environment: env,
+  environment: prodEnv,
   deploymentStrategy: appconfig.DeploymentStrategy.fromDeploymentStrategyId(
     appconfig.PredefinedDeploymentStrategy.LINEAR_50_PERCENT_EVERY_30_SECONDS
   )
@@ -198,15 +187,13 @@ By default, applications, configuration profiles, and hosted configuration versi
 The default behavior described above can be altered using the `removalPolicy` property one each AppConfig construct. Some examples are below.
 
 ```ts
-const env = new appconfig.Environment(this, 'ProdEnv', {
+const prodEnv = new appconfig.Environment(this, 'ProdEnv', {
   application: app,
-  name: 'Production',
   removalPolicy: cdk.RemovalPolicy.RETAIN
 });
 
 const config = new appconfig.HostedConfigurationProfile(this, 'Config', {
   application: app,
-  name: 'My Config',
   removalPolicy: cdk.RemovalPolicy.DESTROY
 });
 

--- a/packages/cdk-appconfig/README.md
+++ b/packages/cdk-appconfig/README.md
@@ -171,8 +171,7 @@ new appconfig.Deployment(this, 'Deployment', {
 
 Deployment strategies are global (not defined within your Application scope), so you may prefer to import them. You can import Deployment strategies that you created, or ones that are predefined by AppConfig.
 
-- `DeploymentStrategy.fromId(deploymentStrategyId)`
-- `DeploymentStrategy.fromPredefined(predefinedDeploymentStrategy)`
+- `DeploymentStrategy.fromDeploymentStrategyId(deploymentStrategyId)`
 
 Example using a predefined deployment strategy:
 
@@ -182,7 +181,7 @@ new appconfig.Deployment(this, 'Deployment', {
   configurationProfile: configProfile,
   configurationVersionNumber: configVersion.versionNumber,
   environment: env,
-  deploymentStrategy: appconfig.DeploymentStrategy.fromPredefined(
+  deploymentStrategy: appconfig.DeploymentStrategy.fromDeploymentStrategyId(
     appconfig.PredefinedDeploymentStrategy.LINEAR_50_PERCENT_EVERY_30_SECONDS
   )
 });

--- a/packages/cdk-appconfig/lib/application.ts
+++ b/packages/cdk-appconfig/lib/application.ts
@@ -6,7 +6,7 @@ export interface IApplication extends cdk.IResource {
 }
 
 export interface ApplicationProps {
-  readonly name: string;
+  readonly name?: string;
   readonly description?: string;
   readonly removalPolicy?: cdk.RemovalPolicy;
 }
@@ -16,21 +16,19 @@ export class Application extends cdk.Resource implements IApplication, cdk.ITagg
   public readonly tags: cdk.TagManager;
   private readonly resource: appconfig.CfnApplication;
 
-  constructor(scope: cdk.Construct, id: string, props: ApplicationProps) {
-    super(scope, id, {
-      physicalName: props.name
-    });
+  constructor(scope: cdk.Construct, id: string, props?: ApplicationProps) {
+    super(scope, id);
 
     const DEFAULT_REMOVAL_POLICY = cdk.RemovalPolicy.RETAIN;
 
     this.tags = new cdk.TagManager(cdk.TagType.STANDARD, 'AWS::AppConfig::Application');
 
     this.resource = new appconfig.CfnApplication(this, 'Resource', {
-      name: props.name,
-      description: props.description
+      name: props?.name || cdk.Names.uniqueId(this),
+      description: props?.description
     });
 
-    this.resource.applyRemovalPolicy(props.removalPolicy || DEFAULT_REMOVAL_POLICY);
+    this.resource.applyRemovalPolicy(props?.removalPolicy || DEFAULT_REMOVAL_POLICY);
 
     this.applicationId = this.resource.ref;
   }

--- a/packages/cdk-appconfig/lib/configuration_profile.ts
+++ b/packages/cdk-appconfig/lib/configuration_profile.ts
@@ -2,7 +2,7 @@ import * as cdk from '@aws-cdk/core';
 import * as appconfig from '@aws-cdk/aws-appconfig';
 import * as s3 from '@aws-cdk/aws-s3';
 
-import { Application } from './application';
+import { IApplication } from './application';
 import { Validator } from './validator';
 
 export interface IConfigurationProfile extends cdk.IResource {
@@ -10,7 +10,7 @@ export interface IConfigurationProfile extends cdk.IResource {
 }
 
 export interface ConfigurationProfileBaseProps {
-  readonly application: Application;
+  readonly application: IApplication;
   readonly name?: string;
   readonly validators?: Validator[];
   readonly description?: string;

--- a/packages/cdk-appconfig/lib/configuration_profile.ts
+++ b/packages/cdk-appconfig/lib/configuration_profile.ts
@@ -11,7 +11,7 @@ export interface IConfigurationProfile extends cdk.IResource {
 
 export interface ConfigurationProfileBaseProps {
   readonly application: Application;
-  readonly name: string;
+  readonly name?: string;
   readonly validators?: Validator[];
   readonly description?: string;
   readonly removalPolicy?: cdk.RemovalPolicy;
@@ -27,9 +27,7 @@ export class ConfigurationProfile extends cdk.Resource implements IConfiguration
   private readonly resource: appconfig.CfnConfigurationProfile;
 
   constructor(scope: cdk.Construct, id: string, props: ConfigurationProfileProps) {
-    super(scope, id, {
-      physicalName: props.name
-    });
+    super(scope, id);
 
     const DEFAULT_REMOVAL_POLICY = cdk.RemovalPolicy.RETAIN;
 
@@ -39,7 +37,7 @@ export class ConfigurationProfile extends cdk.Resource implements IConfiguration
 
     this.resource = new appconfig.CfnConfigurationProfile(this, 'Resource', {
       applicationId: props.application.applicationId,
-      name: props.name,
+      name: props.name || cdk.Names.uniqueId(this),
       description: props.description,
       locationUri: props.locationUri,
       validators: validatorConfigs

--- a/packages/cdk-appconfig/lib/configuration_profile.ts
+++ b/packages/cdk-appconfig/lib/configuration_profile.ts
@@ -40,7 +40,7 @@ export class ConfigurationProfile extends cdk.Resource implements IConfiguration
       name: props.name || cdk.Names.uniqueId(this),
       description: props.description,
       locationUri: props.locationUri,
-      validators: validatorConfigs
+      validators: validatorConfigs?.map((config) => ({ ...config, type: config.validatorType }))
     });
 
     this.resource.applyRemovalPolicy(props.removalPolicy || DEFAULT_REMOVAL_POLICY);

--- a/packages/cdk-appconfig/lib/deployment.ts
+++ b/packages/cdk-appconfig/lib/deployment.ts
@@ -1,17 +1,17 @@
 import * as cdk from '@aws-cdk/core';
 import * as appconfig from '@aws-cdk/aws-appconfig';
 
-import { Application } from './application';
+import { IApplication } from './application';
 import { IConfigurationProfile } from './configuration_profile';
 import { IDeploymentStrategy } from './deployment_strategy';
-import { Environment } from './environment';
+import { IEnvironment } from './environment';
 
 export interface DeploymentProps {
-  readonly application: Application;
+  readonly application: IApplication;
   readonly configurationProfile: IConfigurationProfile;
   readonly configurationVersionNumber: string;
   readonly deploymentStrategy: IDeploymentStrategy;
-  readonly environment: Environment;
+  readonly environment: IEnvironment;
   readonly description?: string;
 }
 

--- a/packages/cdk-appconfig/lib/deployment_strategy.ts
+++ b/packages/cdk-appconfig/lib/deployment_strategy.ts
@@ -31,7 +31,7 @@ export enum DeploymentStrategyGrowthType {
 }
 
 export interface DeploymentStrategyProps {
-  readonly name: string;
+  readonly name?: string;
   readonly deploymentDurationInMinutes: number;
   readonly growthFactor: number;
   readonly replicateTo?: DeploymentStrategyReplication;
@@ -47,9 +47,7 @@ export class DeploymentStrategy extends cdk.Resource implements IDeploymentStrat
   private readonly resource: appconfig.CfnDeploymentStrategy;
 
   constructor(scope: cdk.Construct, id: string, props: DeploymentStrategyProps) {
-    super(scope, id, {
-      physicalName: props.name
-    });
+    super(scope, id);
 
     const DEFAULT_REPLICATION = DeploymentStrategyReplication.NONE;
     const DEFAULT_REMOVAL_POLICY = cdk.RemovalPolicy.DESTROY;
@@ -57,7 +55,7 @@ export class DeploymentStrategy extends cdk.Resource implements IDeploymentStrat
     this.tags = new cdk.TagManager(cdk.TagType.STANDARD, 'AWS::AppConfig::DeploymentStrategy');
 
     this.resource = new appconfig.CfnDeploymentStrategy(this, 'Resource', {
-      name: props.name,
+      name: props.name || cdk.Names.uniqueId(this),
       deploymentDurationInMinutes: props.deploymentDurationInMinutes,
       growthFactor: props.growthFactor,
       replicateTo: props.replicateTo || DEFAULT_REPLICATION,

--- a/packages/cdk-appconfig/lib/deployment_strategy.ts
+++ b/packages/cdk-appconfig/lib/deployment_strategy.ts
@@ -5,7 +5,7 @@ export interface IDeploymentStrategy extends cdk.IResource {
   readonly deploymentStrategyId: string;
 }
 
-export class DeploymentStrategyImport extends cdk.Resource implements IDeploymentStrategy {
+export class ImportedDeploymentStrategy extends cdk.Resource implements IDeploymentStrategy {
   public readonly deploymentStrategyId: string;
 
   constructor(scope: cdk.Construct, id: string, deploymentStrategyId: string) {
@@ -69,16 +69,12 @@ export class DeploymentStrategy extends cdk.Resource implements IDeploymentStrat
     this.deploymentStrategyId = this.resource.ref;
   }
 
-  public static fromId(scope: cdk.Construct, id: string, deploymentStrategyId: string) {
-    return new DeploymentStrategyImport(scope, id, deploymentStrategyId);
-  }
-
-  public static fromPredefined(
+  public static fromDeploymentStrategyId(
     scope: cdk.Construct,
     id: string,
-    predefinedDeploymentStrategy: PredefinedDeploymentStrategy
+    deploymentStrategyId: PredefinedDeploymentStrategy | string
   ) {
-    return new DeploymentStrategyImport(scope, id, predefinedDeploymentStrategy);
+    return new ImportedDeploymentStrategy(scope, id, deploymentStrategyId);
   }
 
   protected prepare() {

--- a/packages/cdk-appconfig/lib/environment.ts
+++ b/packages/cdk-appconfig/lib/environment.ts
@@ -5,7 +5,7 @@ import { Application } from './application';
 
 export interface EnvironmentProps {
   readonly application: Application;
-  readonly name: string;
+  readonly name?: string;
   readonly description?: string;
   readonly removalPolicy?: cdk.RemovalPolicy;
 }
@@ -16,9 +16,7 @@ export class Environment extends cdk.Resource implements cdk.ITaggable {
   private readonly resource: appconfig.CfnEnvironment;
 
   constructor(scope: cdk.Construct, id: string, props: EnvironmentProps) {
-    super(scope, id, {
-      physicalName: props.name
-    });
+    super(scope, id);
 
     const DEFAULT_REMOVAL_POLICY = cdk.RemovalPolicy.DESTROY;
 
@@ -26,7 +24,7 @@ export class Environment extends cdk.Resource implements cdk.ITaggable {
 
     this.resource = new appconfig.CfnEnvironment(this, 'Resource', {
       applicationId: props.application.applicationId,
-      name: props.name,
+      name: props.name || cdk.Names.uniqueId(this),
       description: props.description
       // TODO: monitors
       // monitors: []

--- a/packages/cdk-appconfig/lib/environment.ts
+++ b/packages/cdk-appconfig/lib/environment.ts
@@ -1,16 +1,20 @@
 import * as cdk from '@aws-cdk/core';
 import * as appconfig from '@aws-cdk/aws-appconfig';
 
-import { Application } from './application';
+import { IApplication } from './application';
+
+export interface IEnvironment extends cdk.IResource {
+  readonly environmentId: string;
+}
 
 export interface EnvironmentProps {
-  readonly application: Application;
+  readonly application: IApplication;
   readonly name?: string;
   readonly description?: string;
   readonly removalPolicy?: cdk.RemovalPolicy;
 }
 
-export class Environment extends cdk.Resource implements cdk.ITaggable {
+export class Environment extends cdk.Resource implements IEnvironment, cdk.ITaggable {
   public readonly environmentId: string;
   public readonly tags: cdk.TagManager;
   private readonly resource: appconfig.CfnEnvironment;

--- a/packages/cdk-appconfig/lib/hosted_configuration_version.ts
+++ b/packages/cdk-appconfig/lib/hosted_configuration_version.ts
@@ -5,7 +5,7 @@ import * as lambda from '@aws-cdk/aws-lambda';
 import * as cr from '@aws-cdk/custom-resources';
 import * as iam from '@aws-cdk/aws-iam';
 
-import { Application } from './application';
+import { IApplication } from './application';
 import { IConfigurationProfile } from './configuration_profile';
 import { ContentType, Content } from './content';
 
@@ -24,8 +24,12 @@ function uppercaseProperties(props: { [key: string]: any }): { [key: string]: an
   }, {});
 }
 
+export interface IHostedConfigurationVersion {
+  readonly versionNumber: string;
+}
+
 export interface HostedConfigurationVersionProps {
-  readonly application: Application;
+  readonly application: IApplication;
   readonly configurationProfile: IConfigurationProfile;
   readonly contentType: ContentType;
   readonly content: Content;
@@ -35,7 +39,7 @@ export interface HostedConfigurationVersionProps {
   readonly removalPolicy?: cdk.RemovalPolicy;
 }
 
-export class HostedConfigurationVersion extends cdk.Resource {
+export class HostedConfigurationVersion extends cdk.Resource implements IHostedConfigurationVersion {
   public readonly versionNumber: string;
 
   constructor(scope: cdk.Construct, id: string, props: HostedConfigurationVersionProps) {

--- a/packages/cdk-appconfig/lib/validator.ts
+++ b/packages/cdk-appconfig/lib/validator.ts
@@ -8,7 +8,6 @@ export enum ValidatorType {
 }
 
 export interface ValidatorConfig {
-  // @ts-ignore: (JSII5018) this must be named "type" to be compatible with lower level construct
   readonly type: ValidatorType;
   readonly content: string;
 }

--- a/packages/cdk-appconfig/lib/validator.ts
+++ b/packages/cdk-appconfig/lib/validator.ts
@@ -8,7 +8,7 @@ export enum ValidatorType {
 }
 
 export interface ValidatorConfig {
-  readonly type: ValidatorType;
+  readonly validatorType: ValidatorType;
   readonly content: string;
 }
 
@@ -45,7 +45,7 @@ export class InlineJsonSchemaValidator extends JsonSchemaValidator {
 
   bind(_scope: cdk.Construct): ValidatorConfig {
     return {
-      type: ValidatorType.JSON_SCHEMA,
+      validatorType: ValidatorType.JSON_SCHEMA,
       content: this.content
     };
   }
@@ -66,7 +66,7 @@ export class LambdaValidator extends Validator {
     });
 
     return {
-      type: ValidatorType.LAMBDA,
+      validatorType: ValidatorType.LAMBDA,
       content: this.lambdaFunction.functionArn
     };
   }

--- a/packages/cdk-appconfig/test/application.test.ts
+++ b/packages/cdk-appconfig/test/application.test.ts
@@ -1,4 +1,4 @@
-import { expect as expectCDK, haveResource, ResourcePart } from '@aws-cdk/assert';
+import { anything, expect as expectCDK, haveResource, ResourcePart } from '@aws-cdk/assert';
 import * as cdk from '@aws-cdk/core';
 
 import { buildCdkStack, buildApplication } from './helpers';
@@ -8,10 +8,7 @@ describe('AppConfig', () => {
   describe('Application', () => {
     describe('with required props', () => {
       const stack = buildCdkStack();
-
-      const application = new Application(stack, 'MyApplication', {
-        name: 'MyApp'
-      });
+      const application = new Application(stack, 'MyApplication');
 
       it('has an application id', () => {
         expect(typeof application.applicationId).toEqual('string');
@@ -20,7 +17,7 @@ describe('AppConfig', () => {
       it('creates an application resource with required properties', () => {
         expectCDK(stack).to(
           haveResource('AWS::AppConfig::Application', {
-            Name: 'MyApp'
+            Name: anything()
           })
         );
       });

--- a/packages/cdk-appconfig/test/configuration_profile.test.ts
+++ b/packages/cdk-appconfig/test/configuration_profile.test.ts
@@ -20,7 +20,6 @@ describe('AppConfig', () => {
 
       const profile = new ConfigurationProfile(stack, 'MyProfile', {
         application,
-        name: 'MyProfile',
         locationUri: 'hosted'
       });
 
@@ -34,7 +33,7 @@ describe('AppConfig', () => {
             ApplicationId: {
               Ref: anything()
             },
-            Name: 'MyProfile',
+            Name: anything(),
             LocationUri: 'hosted'
           })
         );

--- a/packages/cdk-appconfig/test/deployment_strategy.test.ts
+++ b/packages/cdk-appconfig/test/deployment_strategy.test.ts
@@ -105,24 +105,20 @@ describe('AppConfig', () => {
       });
     });
 
-    describe('fromPredefined', () => {
+    describe('fromDeploymentStrategyId', () => {
       const stack = buildCdkStack();
-      const strategy = DeploymentStrategy.fromPredefined(
-        stack,
-        'PredefinedStrategy',
-        PredefinedDeploymentStrategy.ALL_AT_ONCE
-      );
 
-      it('has a deployment strategy id', () => {
+      it('support predefined deployment strategies', () => {
+        const strategy = DeploymentStrategy.fromDeploymentStrategyId(
+          stack,
+          'PredefinedStrategy',
+          PredefinedDeploymentStrategy.ALL_AT_ONCE
+        );
         expect(strategy.deploymentStrategyId).toEqual('AppConfig.AllAtOnce');
       });
-    });
 
-    describe('fromId', () => {
-      it('has a deployment strategy id', () => {
-        const stack = buildCdkStack();
-        const strategy = DeploymentStrategy.fromId(stack, 'ImportedStrategy', 'abc123');
-
+      it('supports custom deployment strategies', () => {
+        const strategy = DeploymentStrategy.fromDeploymentStrategyId(stack, 'ImportedStrategy', 'abc123');
         expect(strategy.deploymentStrategyId).toEqual('abc123');
       });
     });

--- a/packages/cdk-appconfig/test/deployment_strategy.test.ts
+++ b/packages/cdk-appconfig/test/deployment_strategy.test.ts
@@ -1,4 +1,4 @@
-import { expect as expectCDK, haveResource, ResourcePart } from '@aws-cdk/assert';
+import { anything, expect as expectCDK, haveResource, ResourcePart } from '@aws-cdk/assert';
 import { buildCdkStack } from './helpers';
 import * as cdk from '@aws-cdk/core';
 import {
@@ -14,7 +14,6 @@ describe('AppConfig', () => {
       const stack = buildCdkStack();
 
       const strategy = new DeploymentStrategy(stack, 'MyDeploymentStrategy', {
-        name: 'My Deployment Strategy',
         deploymentDurationInMinutes: 0,
         growthFactor: 100
       });
@@ -26,7 +25,7 @@ describe('AppConfig', () => {
       it('creates a deployment strategy with required properties', () => {
         expectCDK(stack).to(
           haveResource('AWS::AppConfig::DeploymentStrategy', {
-            Name: 'My Deployment Strategy',
+            Name: anything(),
             DeploymentDurationInMinutes: 0,
             GrowthFactor: 100,
             ReplicateTo: 'NONE'

--- a/packages/cdk-appconfig/test/environment.test.ts
+++ b/packages/cdk-appconfig/test/environment.test.ts
@@ -11,8 +11,7 @@ describe('AppConfig', () => {
       const application = buildApplication(stack);
 
       const environment = new Environment(stack, 'MyEnvironment', {
-        application,
-        name: 'MyEnv'
+        application
       });
 
       it('has an environment id', () => {
@@ -25,7 +24,7 @@ describe('AppConfig', () => {
             ApplicationId: {
               Ref: anything()
             },
-            Name: 'MyEnv'
+            Name: anything()
           })
         );
       });

--- a/packages/cdk-appconfig/test/example_stack.test.ts
+++ b/packages/cdk-appconfig/test/example_stack.test.ts
@@ -35,7 +35,7 @@ class ExampleStack extends cdk.Stack {
       configurationProfile,
       configurationVersionNumber: configurationVersion.versionNumber,
       environment,
-      deploymentStrategy: appconfig.DeploymentStrategy.fromPredefined(
+      deploymentStrategy: appconfig.DeploymentStrategy.fromDeploymentStrategyId(
         this,
         'AllAtOnce',
         appconfig.PredefinedDeploymentStrategy.ALL_AT_ONCE

--- a/packages/cdk-appconfig/test/helpers.ts
+++ b/packages/cdk-appconfig/test/helpers.ts
@@ -22,7 +22,7 @@ export function buildCdkStack(options?: { tags?: Tags }) {
   return stack;
 }
 
-export function buildApplication(scope: cdk.Construct, options?: { name?: string }) {
+export function buildApplication(scope: cdk.Construct, options?: { name?: string }): appconfig.IApplication {
   return new appconfig.Application(scope, 'MyApplication', {
     name: options?.name || 'MyApplication'
   });
@@ -30,8 +30,8 @@ export function buildApplication(scope: cdk.Construct, options?: { name?: string
 
 export function buildHostedProfile(
   scope: cdk.Construct,
-  options?: { application?: appconfig.Application; name?: string }
-) {
+  options?: { application?: appconfig.IApplication; name?: string }
+): appconfig.IConfigurationProfile {
   return new appconfig.HostedConfigurationProfile(scope, 'MyHostedConfigurationProfile', {
     application: options?.application || buildApplication(scope),
     name: options?.name || 'MyHostedConfigurationProfile'
@@ -40,8 +40,8 @@ export function buildHostedProfile(
 
 export function buildEnvironment(
   scope: cdk.Construct,
-  options?: { application?: appconfig.Application; name?: string }
-) {
+  options?: { application?: appconfig.IApplication; name?: string }
+): appconfig.IEnvironment {
   return new appconfig.Environment(scope, 'MyEnvironment', {
     application: options?.application || buildApplication(scope),
     name: options?.name || 'MyEnvironment'
@@ -51,7 +51,7 @@ export function buildEnvironment(
 export function buildDeploymentStrategy(
   scope: cdk.Construct,
   options?: { name?: string; deploymentDurationInMinutes?: number; growthFactor?: number }
-) {
+): appconfig.IDeploymentStrategy {
   return new appconfig.DeploymentStrategy(scope, 'MyDeploymentStrategy', {
     name: options?.name || 'MyDeploymentStrategy',
     deploymentDurationInMinutes: options?.deploymentDurationInMinutes || 0,

--- a/packages/cdk-appconfig/test/validator.test.ts
+++ b/packages/cdk-appconfig/test/validator.test.ts
@@ -27,7 +27,7 @@ describe('AppConfig', () => {
         const validatorConfig = inlineSchemaValidator.bind(stack);
 
         it('returns a ContentConfig with inline JSON schema', () => {
-          expect(validatorConfig.type).toEqual('JSON_SCHEMA');
+          expect(validatorConfig.validatorType).toEqual('JSON_SCHEMA');
           expect(validatorConfig.content).toEqual(jsonSchema);
         });
       });


### PR DESCRIPTION
* Names on all AppConfig resources are optional (auto-generated if omitted)
* Don't explicitly set physical name (let CDK auto-generate physical names)
* Fix support for interfaces
* Fix typescript warning for reserved word "type"
* More conventional static method names used for importing resources
* Simpler examples in docs