### PR TITLE
Add support for alarms on environments

### DIFF
--- a/packages/cdk-appconfig-examples/package.json
+++ b/packages/cdk-appconfig-examples/package.json
@@ -40,6 +40,7 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
+    "@aws-cdk/aws-cloudwatch": "^1.108.1",
     "@aws-cdk/aws-lambda": "^1.108.1",
     "@aws-cdk/core": "1.108.1",
     "@cuperman/cdk-appconfig": "^0.6.0",

--- a/packages/cdk-appconfig-examples/test/hosted-configuration-stack.test.ts
+++ b/packages/cdk-appconfig-examples/test/hosted-configuration-stack.test.ts
@@ -2,7 +2,7 @@ import { expect as expectCDK, haveResource } from '@aws-cdk/assert';
 import * as cdk from '@aws-cdk/core';
 import { HostedConfigurationStack } from '../lib';
 
-describe('CdkExamplesStack', () => {
+describe('HostedConfigurationStack', () => {
   const app = new cdk.App();
   const stack = new HostedConfigurationStack(app, 'MyHostedConfigExample');
 

--- a/packages/cdk-appconfig-examples/test/lambda-extension-stack.test.ts
+++ b/packages/cdk-appconfig-examples/test/lambda-extension-stack.test.ts
@@ -1,8 +1,8 @@
-import { expect as expectCDK, haveResource, haveResourceLike } from '@aws-cdk/assert';
+import { anything, expect as expectCDK, haveResource, haveResourceLike } from '@aws-cdk/assert';
 import * as cdk from '@aws-cdk/core';
 import { LambdaExtensionStack } from '../lib';
 
-describe('CdkExamplesStack', () => {
+describe('LambdaExtensionStack', () => {
   const app = new cdk.App();
   const stack = new LambdaExtensionStack(app, 'MyLambdaExtensionExample');
 
@@ -47,6 +47,23 @@ describe('CdkExamplesStack', () => {
             }
           ]
         }
+      })
+    );
+  });
+
+  it('has an alarm that triggers on lambda errors', () => {
+    expectCDK(stack).to(
+      haveResource('AWS::CloudWatch::Alarm', {
+        Namespace: 'AWS/Lambda',
+        MetricName: 'Errors',
+        Dimensions: [
+          {
+            Name: 'FunctionName',
+            Value: {
+              Ref: anything()
+            }
+          }
+        ]
       })
     );
   });

--- a/packages/cdk-appconfig-examples/yarn.lock
+++ b/packages/cdk-appconfig-examples/yarn.lock
@@ -62,7 +62,7 @@
     "@aws-cdk/cx-api" "1.108.1"
     constructs "^3.3.69"
 
-"@aws-cdk/aws-cloudwatch@1.108.1":
+"@aws-cdk/aws-cloudwatch@1.108.1", "@aws-cdk/aws-cloudwatch@^1.108.1":
   version "1.108.1"
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.108.1.tgz#49169a32bda0376bb6820aa561b394aafdaf3603"
   integrity sha512-Qm4Pf8YcrM5XmGW/YyS9CKuoYT254Ffch7axF4W6swC6XUb6Vg5umYji8yWLmlT4EwQzd4EBdHZkjX9ezWP70g==

--- a/packages/cdk-appconfig-handler-hello-world/index.test.ts
+++ b/packages/cdk-appconfig-handler-hello-world/index.test.ts
@@ -13,9 +13,9 @@ describe('index', () => {
     const context = {};
 
     beforeEach(() => {
-      process.env.AWS_APPCONFIG_APPLICATION_ID = 'helloworld';
-      process.env.AWS_APPCONFIG_ENVIRONMENT_ID = 'demo';
-      process.env.AWS_APPCONFIG_CONFIGURATION_PROFILE_ID = 'ExclamationPoints';
+      process.env.AWS_APPCONFIG_APPLICATION_NAME = 'helloworld';
+      process.env.AWS_APPCONFIG_ENVIRONMENT_NAME = 'demo';
+      process.env.AWS_APPCONFIG_CONFIGURATION_PROFILE_NAME = 'ExclamationPoints';
     });
 
     afterEach(() => {

--- a/packages/cdk-appconfig-handler-hello-world/index.ts
+++ b/packages/cdk-appconfig-handler-hello-world/index.ts
@@ -36,12 +36,12 @@ async function fetch(url: string): Promise<string> {
 }
 
 async function getConfiguredNumberOf(configurationType: string, defaultValue: number): Promise<number> {
-  const applicationId = requireEnvironmentVariable('AWS_APPCONFIG_APPLICATION_ID');
-  const environmentId = requireEnvironmentVariable('AWS_APPCONFIG_ENVIRONMENT_ID');
-  const configurationProfileId = requireEnvironmentVariable('AWS_APPCONFIG_CONFIGURATION_PROFILE_ID');
+  const applicationName = requireEnvironmentVariable('AWS_APPCONFIG_APPLICATION_NAME');
+  const environmentName = requireEnvironmentVariable('AWS_APPCONFIG_ENVIRONMENT_NAME');
+  const configurationProfileName = requireEnvironmentVariable('AWS_APPCONFIG_CONFIGURATION_PROFILE_NAME');
   const httpPort = requireEnvironmentVariable('AWS_APPCONFIG_EXTENSION_HTTP_PORT', '2772');
 
-  const url = `http://localhost:${httpPort}/applications/${applicationId}/environments/${environmentId}/configurations/${configurationProfileId}`;
+  const url = `http://localhost:${httpPort}/applications/${applicationName}/environments/${environmentName}/configurations/${configurationProfileName}`;
 
   try {
     const json = await fetch(url);

--- a/packages/cdk-appconfig/lib/application.ts
+++ b/packages/cdk-appconfig/lib/application.ts
@@ -13,6 +13,7 @@ export interface ApplicationProps {
 
 export class Application extends cdk.Resource implements IApplication, cdk.ITaggable {
   public readonly applicationId: string;
+  public readonly applicationName: string;
   public readonly tags: cdk.TagManager;
   private readonly resource: appconfig.CfnApplication;
 
@@ -31,6 +32,7 @@ export class Application extends cdk.Resource implements IApplication, cdk.ITagg
     this.resource.applyRemovalPolicy(props?.removalPolicy || DEFAULT_REMOVAL_POLICY);
 
     this.applicationId = this.resource.ref;
+    this.applicationName = this.resource.name;
   }
 
   protected prepare() {

--- a/packages/cdk-appconfig/lib/configuration_profile.ts
+++ b/packages/cdk-appconfig/lib/configuration_profile.ts
@@ -26,6 +26,7 @@ export interface ConfigurationProfileProps extends ConfigurationProfileBaseProps
 export class ConfigurationProfile extends cdk.Resource implements IConfigurationProfile, cdk.ITaggable {
   public readonly application: IApplication;
   public readonly configurationProfileId: string;
+  public readonly configurationProfileName: string;
   public readonly tags: cdk.TagManager;
   private readonly resource: appconfig.CfnConfigurationProfile;
 
@@ -50,6 +51,7 @@ export class ConfigurationProfile extends cdk.Resource implements IConfiguration
     this.resource.applyRemovalPolicy(props.removalPolicy || DEFAULT_REMOVAL_POLICY);
 
     this.configurationProfileId = this.resource.ref;
+    this.configurationProfileName = this.resource.name;
   }
 
   protected prepare() {

--- a/packages/cdk-appconfig/lib/environment.ts
+++ b/packages/cdk-appconfig/lib/environment.ts
@@ -19,8 +19,11 @@ export interface EnvironmentProps {
 
 export class Environment extends cdk.Resource implements IEnvironment, cdk.ITaggable {
   public readonly environmentId: string;
+  public readonly environmentName: string;
+  public readonly alarms: cloudwatch.IAlarm[];
   public readonly tags: cdk.TagManager;
   private readonly resource: appconfig.CfnEnvironment;
+  private alarmRole?: iam.IRole;
 
   constructor(scope: cdk.Construct, id: string, props: EnvironmentProps) {
     super(scope, id);
@@ -29,41 +32,49 @@ export class Environment extends cdk.Resource implements IEnvironment, cdk.ITagg
 
     this.tags = new cdk.TagManager(cdk.TagType.STANDARD, 'AWS::AppConfig::Environment');
 
-    const alarmRole = new iam.Role(this, 'AlarmRole', {
-      assumedBy: new iam.ServicePrincipal('appconfig.amazonaws.com'),
-      inlinePolicies: {
-        SSMCloudWatchAlarmDiscoveryRole: new iam.PolicyDocument({
-          statements: [
-            new iam.PolicyStatement({
-              effect: iam.Effect.ALLOW,
-              actions: ['cloudwatch:DescribeAlarms'],
-              resources: ['*']
-            })
-          ]
-        })
-      }
-    });
-
-    const monitors: appconfig.CfnEnvironment.MonitorsProperty[] | undefined = props.alarms?.map((alarm) => {
-      return {
-        alarmArn: alarm.alarmArn,
-        alarmRoleArn: alarmRole.roleArn
-      };
-    });
+    this.alarms = [];
+    props.alarms?.forEach((alarm) => this.alarms.push(alarm));
 
     this.resource = new appconfig.CfnEnvironment(this, 'Resource', {
       applicationId: props.application.applicationId,
       name: props.name || cdk.Names.uniqueId(this),
-      description: props.description,
-      monitors
+      description: props.description
     });
 
     this.resource.applyRemovalPolicy(props.removalPolicy || DEFAULT_REMOVAL_POLICY);
 
     this.environmentId = this.resource.ref;
+    this.environmentName = this.resource.name;
   }
 
   protected prepare() {
+    if (this.alarms.length > 0 && !this.alarmRole) {
+      this.alarmRole = new iam.Role(this, 'AlarmRole', {
+        assumedBy: new iam.ServicePrincipal('appconfig.amazonaws.com'),
+        inlinePolicies: {
+          SSMCloudWatchAlarmDiscoveryRole: new iam.PolicyDocument({
+            statements: [
+              new iam.PolicyStatement({
+                effect: iam.Effect.ALLOW,
+                actions: ['cloudwatch:DescribeAlarms'],
+                resources: ['*']
+              })
+            ]
+          })
+        }
+      });
+    }
+
+    this.resource.monitors = this.alarms.map((alarm) => {
+      return {
+        alarmArn: alarm.alarmArn,
+        alarmRoleArn: this.alarmRole?.roleArn
+      };
+    });
     this.resource.tags = this.tags.renderTags();
+  }
+
+  addAlarm(alarm: cloudwatch.IAlarm) {
+    this.alarms.push(alarm);
   }
 }

--- a/packages/cdk-appconfig/package.json
+++ b/packages/cdk-appconfig/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@aws-cdk/aws-appconfig": "^1.0.0",
+    "@aws-cdk/aws-cloudwatch": "^1.0.0",
     "@aws-cdk/aws-iam": "^1.0.0",
     "@aws-cdk/aws-lambda": "^1.0.0",
     "@aws-cdk/aws-s3": "^1.0.0",
@@ -51,6 +52,7 @@
   "peerDependencies": {
     "@aws-cdk/assets": "^1.0.0",
     "@aws-cdk/aws-appconfig": "^1.0.0",
+    "@aws-cdk/aws-cloudwatch": "^1.0.0",
     "@aws-cdk/aws-iam": "^1.0.0",
     "@aws-cdk/aws-lambda": "^1.0.0",
     "@aws-cdk/aws-s3": "^1.0.0",

--- a/packages/cdk-appconfig/test/application.test.ts
+++ b/packages/cdk-appconfig/test/application.test.ts
@@ -14,6 +14,10 @@ describe('AppConfig', () => {
         expect(typeof application.applicationId).toEqual('string');
       });
 
+      it('has an application name', () => {
+        expect(typeof application.applicationName).toEqual('string');
+      });
+
       it('creates an application resource with required properties', () => {
         expectCDK(stack).to(
           haveResource('AWS::AppConfig::Application', {
@@ -39,10 +43,14 @@ describe('AppConfig', () => {
     describe('with optional props', () => {
       const stack = buildCdkStack();
 
-      new Application(stack, 'MyApplication', {
+      const application = new Application(stack, 'MyApplication', {
         name: 'MyApp',
         description: 'My application',
         removalPolicy: cdk.RemovalPolicy.DESTROY
+      });
+
+      it('has a specific application name', () => {
+        expect(application.applicationName).toEqual('MyApp');
       });
 
       it('creates an application resource with optional properties', () => {

--- a/packages/cdk-appconfig/test/configuration_profile.test.ts
+++ b/packages/cdk-appconfig/test/configuration_profile.test.ts
@@ -28,6 +28,10 @@ describe('AppConfig', () => {
           expect(typeof profile.configurationProfileId).toEqual('string');
         });
 
+        it('has a configuration profile name', () => {
+          expect(typeof profile.configurationProfileName).toEqual('string');
+        });
+
         it('creates a configuration profile resource with required properties', () => {
           expectCDK(stack).to(
             haveResource('AWS::AppConfig::ConfigurationProfile', {
@@ -58,12 +62,16 @@ describe('AppConfig', () => {
         const stack = buildCdkStack();
         const application = buildApplication(stack, 'MyApplication');
 
-        new ConfigurationProfile(stack, 'MyProfile', {
+        const profile = new ConfigurationProfile(stack, 'MyProfile', {
           application,
           name: 'MyProfile',
           locationUri: 'hosted',
           description: 'My configuration profile',
           removalPolicy: cdk.RemovalPolicy.DESTROY
+        });
+
+        it('has a specific configuration profile name', () => {
+          expect(profile.configurationProfileName).toEqual('MyProfile');
         });
 
         it('creates a configuration profile resource with optional properties', () => {

--- a/packages/cdk-appconfig/test/helpers.ts
+++ b/packages/cdk-appconfig/test/helpers.ts
@@ -1,5 +1,6 @@
 import * as cdk from '@aws-cdk/core';
 import * as appconfig from '../lib';
+import * as cloudwatch from '@aws-cdk/aws-cloudwatch';
 
 interface Tags {
   [key: string]: string;
@@ -61,5 +62,16 @@ export function buildDeploymentStrategy(
     name: options?.name || 'MyDeploymentStrategy',
     deploymentDurationInMinutes: options?.deploymentDurationInMinutes || 0,
     growthFactor: options?.growthFactor || 0
+  });
+}
+
+export function buildAlarm(scope: cdk.Construct): cloudwatch.IAlarm {
+  return new cloudwatch.Alarm(scope, 'Alarm', {
+    metric: new cloudwatch.Metric({
+      namespace: 'namespace',
+      metricName: 'metric'
+    }),
+    threshold: 100,
+    evaluationPeriods: 2
   });
 }


### PR DESCRIPTION
* Support alarms as props to create environment monitors
* Support `environment.addAlarm` method to create environment monitors
* Add alarm to lambda extension example
* Add properties for AppConfig resource names
* Use resources names instead of ids to avoid circular dependencies